### PR TITLE
CATS-2958 | Reenable dedicated SVG generation for edits

### DIFF
--- a/arclamp-generate-svgs
+++ b/arclamp-generate-svgs
@@ -134,7 +134,7 @@ function update_svgs_for_existing_logs() {
   declare -A label_by_fqfn_with_dedicated_svgs=(
     # Fandom change: Generate dedicated SVGs for RecentChanges and disable other defaults
     [SpecialRecentChanges::execute]="RecentChanges"
-  #  [EditAction::show]="EditAction"
+    [EditAction::show]="EditAction"
   #  [MediaWiki::doPreOutputCommit]="PreSend"
   #  [MediaWiki::doPostOutputShutdown]="PostSend"
   )


### PR DESCRIPTION
This will help us identify where exactly time is spent when saving a
page.