### PR TITLE
Generate dedicated SVGs for uploads

### DIFF
--- a/arclamp-generate-svgs
+++ b/arclamp-generate-svgs
@@ -132,9 +132,10 @@ function update_svgs_for_existing_logs() {
   local data_dir="$1"
 
   declare -A label_by_fqfn_with_dedicated_svgs=(
-    # Fandom change: Generate dedicated SVGs for RecentChanges and disable other defaults
+    # Fandom change: Generate dedicated SVGs for RecentChanges, edits and uploads and disable other defaults
     [SpecialRecentChanges::execute]="RecentChanges"
     [EditAction::show]="EditAction"
+    [SpecialUpload::processUpload]="Upload"
   #  [MediaWiki::doPreOutputCommit]="PreSend"
   #  [MediaWiki::doPostOutputShutdown]="PostSend"
   )


### PR DESCRIPTION
There are sporadic user reports of uploads of small files taking >15s, so generate dedicated SVGs to see what's going on there.