### PR TITLE
Add nar-intranet network and unify redis host names

### DIFF
--- a/arclamp-log-dev-dedicated.yaml
+++ b/arclamp-log-dev-dedicated.yaml
@@ -7,6 +7,6 @@ logs:
     period: weekly
     retain: 2
 redis:
-  host: "arclamp-redis"
+  host: "arclamp-log"
   port: 6379
 redis_channel: "arclamp-dedicated"

--- a/arclamp-log-dev.yaml
+++ b/arclamp-log-dev.yaml
@@ -7,5 +7,5 @@ logs:
     period: daily
     retain: 7
 redis:
-  host: "arclamp-redis"
+  host: "arclamp-log"
   port: 6379

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '3.8'
 
 services:
-  arclamp-log:
+  arclamp:
     image: artifactory.wikia-inc.com/platform/arclamp-log:latest
     user: $UID
     build:
@@ -15,7 +15,7 @@ services:
       - ./logs-main:/srv/arclamp/logs
       - ./logs-dedicated:/srv/arclamp/dedicated/logs
     depends_on:
-      - arclamp-redis
+      - arclamp-log
     networks:
       - intranet
 
@@ -43,13 +43,16 @@ services:
       - ./logs-dedicated:/srv/arclamp/logs
       - ./svgs-dedicated:/srv/arclamp/svgs
 
-  arclamp-redis:
+  arclamp-log:
     image: artifactory.wikia-inc.com/dockerhub/redis:6.0.9-alpine
     ports:
       - 6379:6379
     networks:
       - intranet
+      - nar-intranet
 
 networks:
+  nar-intranet:
+    name: nar-intranet
   intranet:
     name: unified-platform_default


### PR DESCRIPTION
We wanna start integrating the NaR apps with Arclamp, and therefore let's add the nar-intranet network so is easier to connect the apps locally. Also, the "service" names should be changed so it more resembles production setup and therefore is easier to maintain with the configurations.

Needed for: https://github.com/Wikia/tvguide-mobileapi/pull/764