### PR TITLE
PLATFORM-11242: Update Redis image version in docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -44,7 +44,7 @@ services:
       - ./svgs-dedicated:/srv/arclamp/svgs
 
   arclamp-log:
-    image: artifactory.wikia-inc.com/dockerhub/redis:6.0.9-alpine
+    image: artifactory.wikia-inc.com/dockerhub-remote/redis:6.2.20-alpine
     ports:
       - 6379:6379
     networks:


### PR DESCRIPTION
Switching to dockerhub-remote as per https://fandom.slack.com/archives/G036SNN1A/p1760615937805499?thread_ts=1760552363.665249&cid=G036SNN1A